### PR TITLE
[REEF-1040] Fix a bug in WatcherTest

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
@@ -55,6 +55,7 @@ public final class TaskRepresenter {
 
   // Mutable state
   private State state = State.INIT;
+  private boolean isFirstRunningMessage = true;
 
   public TaskRepresenter(final String taskId,
                          final EvaluatorContext context,
@@ -125,9 +126,6 @@ public final class TaskRepresenter {
       LOG.log(Level.WARNING, "Received a INIT message for task with id {0}" +
           " which we have seen before. Ignoring the second message", this.taskId);
     } else {
-      final RunningTask runningTask = new RunningTaskImpl(
-          this.evaluatorManager, this.taskId, this.context, this);
-      this.messageDispatcher.onTaskRunning(runningTask);
       this.setState(State.RUNNING);
     }
   }
@@ -138,6 +136,13 @@ public final class TaskRepresenter {
     if (this.isNotRunning()) {
       throw new IllegalStateException("Received a task status message from task " + this.taskId +
           " that is believed to be RUNNING on the Evaluator, but the Driver thinks it is in state " + this.state);
+    }
+
+    if (isFirstRunningMessage) {
+      isFirstRunningMessage = false;
+      final RunningTask runningTask = new RunningTaskImpl(
+          this.evaluatorManager, this.taskId, this.context, this);
+      this.messageDispatcher.onTaskRunning(runningTask);
     }
 
     // fire driver restart task running handler if this is a recovery heartbeat

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStatus.java
@@ -230,6 +230,7 @@ public final class TaskStatus {
    */
   void setRunning() {
     this.setState(State.RUNNING);
+    this.heartbeat();
   }
 
   void setCloseRequested() {

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AllTestsSuite.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AllTestsSuite.java
@@ -34,6 +34,7 @@ import org.apache.reef.tests.messaging.task.TaskMessagingTest;
 import org.apache.reef.tests.statepassing.StatePassingTest;
 import org.apache.reef.tests.subcontexts.SubContextTest;
 import org.apache.reef.tests.taskresubmit.TaskResubmitTest;
+import org.apache.reef.tests.watcher.WatcherTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -57,7 +58,8 @@ import org.junit.runners.Suite;
     ExamplesTestSuite.class,
     ConfigurationProviderTest.class,
     ApplicationTestSuite.class,
-    RuntimeNameTest.class
+    RuntimeNameTest.class,
+    WatcherTest.class,
     })
 public final class AllTestsSuite {
 }


### PR DESCRIPTION
This addressed the issue by
  * Change onTaskRunning to be called when the first RUNNING message arrived from Evaluator
  * Add WatcherTest to AllTestSuite

JIRA:
  [REEF-1040](https://issues.apache.org/jira/browse/REEF-1040)

Author:
  Geon-Woo Kim (gwkim@apache.org)